### PR TITLE
Added templates for karpenter provisioning

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -1,0 +1,57 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.12.0"
+
+  name = local.cluster_name
+  cidr = "10.0.0.0/16"
+
+  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_nat_gateway     = true
+  single_nat_gateway     = true
+  one_nat_gateway_per_az = false
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "owned"
+    "karpenter.sh/discovery" = local.cluster_name
+  }
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "18.17.0"
+
+  cluster_name    = local.cluster_name
+  cluster_version = "1.21"
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  # Required for Karpenter role below
+  enable_irsa = true
+
+  create_cluster_security_group = false
+  create_node_security_group    = false
+
+  eks_managed_node_groups = {
+    initial = {
+      instance_types = ["t3.medium"]
+      create_security_group                 = false
+      attach_cluster_primary_security_group = true
+
+      min_size     = 1
+      max_size     = 1
+      desired_size = 1
+
+      iam_role_additional_policies = [
+        "arn:${local.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      ]
+    }
+  }
+
+  tags = {
+    "karpenter.sh/discovery" = local.cluster_name
+  }
+}

--- a/helm.tf
+++ b/helm.tf
@@ -1,0 +1,42 @@
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1alpha1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
+    }
+  }
+}
+
+resource "helm_release" "karpenter" {
+  namespace        = "karpenter"
+  create_namespace = true
+
+  name       = "karpenter"
+  repository = "https://charts.karpenter.sh"
+  chart      = "karpenter"
+  version    = "v0.8.2"
+
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = module.karpenter_irsa.iam_role_arn
+  }
+
+  set {
+    name  = "clusterName"
+    value = module.eks.cluster_id
+  }
+
+  set {
+    name  = "clusterEndpoint"
+    value = module.eks.cluster_endpoint
+  }
+
+  set {
+    name  = "aws.defaultInstanceProfile"
+    value = aws_iam_instance_profile.karpenter.name
+  }
+}

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_instance_profile" "karpenter" {
+  name = "KarpenterNodeInstanceProfile-${local.cluster_name}"
+  role = module.eks.eks_managed_node_groups["initial"].iam_role_name
+}
+#
+# Karpenter IRSA
+module "karpenter_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "4.17.1"
+
+  role_name                          = "karpenter-controller-${local.cluster_name}"
+  attach_karpenter_controller_policy = true
+
+  karpenter_controller_cluster_id = module.eks.cluster_id
+  karpenter_controller_node_iam_role_arns = [
+    module.eks.eks_managed_node_groups["initial"].iam_role_arn
+  ]
+
+  oidc_providers = {
+    ex = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["karpenter:karpenter"]
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.4"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+locals {
+  cluster_name = "karpenter"
+
+  # Used to determine correct partition (i.e. - `aws`, `aws-gov`, `aws-cn`, etc.)
+  partition = data.aws_partition.current.partition
+}
+
+data "aws_partition" "current" {}

--- a/provisoners/custom-provisioner.yaml
+++ b/provisoners/custom-provisioner.yaml
@@ -1,0 +1,23 @@
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: custom
+spec:
+  requirements:
+    - key: karpenter.sh/capacity-type
+      operator: In
+      values: ["spot","on-demand"]
+   - key: "node.kubernetes.io/instance-type"
+     operator: In
+     values: [ "t3.micro","t3a.micro" ,"t2.medium" ]
+  limits:
+    resources:
+      cpu: 1000
+  provider:
+    subnetSelector:
+      karpenter.sh/discovery: karpenter
+    securityGroupSelector:
+      karpenter.sh/discovery: karpenter
+    tags:
+      karpenter.sh/discovery: karpenter
+  ttlSecondsAfterEmpty: 30

--- a/provisoners/default-provisioner.yaml
+++ b/provisoners/default-provisioner.yaml
@@ -1,0 +1,20 @@
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: default
+spec:
+  requirements:
+    - key: karpenter.sh/capacity-type
+      operator: In
+      values: ["spot","on-demand"]
+  limits:
+    resources:
+      cpu: 1000
+  provider:
+    subnetSelector:
+      karpenter.sh/discovery: karpenter
+    securityGroupSelector:
+      karpenter.sh/discovery: karpenter
+    tags:
+      karpenter.sh/discovery: karpenter
+  ttlSecondsAfterEmpty: 30

--- a/test/aws-cli.yaml
+++ b/test/aws-cli.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: awscli
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: awscli
+  template:
+    metadata:
+      labels:
+        name: awscli
+    spec:
+      nodeSelector:
+        karpenter.sh/provisioner-name: custom
+      containers:
+        - name: awscli
+          image: amazon/aws-cli
+          command:
+            - "sleep"
+            - "604800"
+          resources:
+            requests:
+              cpu: 1
+              memory: 10Mi

--- a/test/deployment.yaml
+++ b/test/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inflate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: inflate
+  template:
+    metadata:
+      labels:
+        app: inflate
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: inflate
+          image: public.ecr.aws/eks-distro/kubernetes/pause:3.2
+          resources:
+            requests:
+              cpu: 1


### PR DESCRIPTION
This PR contains the Terraform scripts to spin up:
1. VPC and other aws network components
2. EKS cluster
3. IAM for karpenter
4. Karpenter on initial worker node